### PR TITLE
Update InteractionWorker_CaughtCheating.cs

### DIFF
--- a/SocialInteractions/InteractionWorker_CaughtCheating.cs
+++ b/SocialInteractions/InteractionWorker_CaughtCheating.cs
@@ -1,68 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using RimWorld;
 using Verse;
-using System.Collections.Generic;
 
 namespace SocialInteractions
 {
+    /// <summary>
+    /// Triggers when a pawn discovers their romantic partner cheating while on a date with someone else.
+    /// Includes distance/LOS/trait-based weighting, cooldown to avoid spam, and letters + thoughts.
+    /// </summary>
     public class InteractionWorker_CaughtCheating : InteractionWorker
     {
+        // ─────────────────────────────────────────────────────────────────────────
+        // Tunables (could be moved to ModSettings if desired)
+        // ─────────────────────────────────────────────────────────────────────────
+        private const float BaseChance = 0.50f;     // 50% base chance (vanilla behavior)
+        private const int NearbyDist8 = 8;          // distance tiers for weighting
+        private const int NearbyDist16 = 16;
+        private const bool RequireLineOfSight = false;  // set true to require LOS for the event
+        private const int CooldownTicks = 60_000;   // ~1 in-game day
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Lightweight cooldown tracking (not saved; resets on reload)
+        // ─────────────────────────────────────────────────────────────────────────
+        private static readonly Dictionary<(int a, int b), int> _cooldown = new();
+
+        private static (int a, int b) PairKey(Pawn p1, Pawn p2)
+        {
+            // Order by thingIDNumber to avoid directional duplicates
+            var a = Math.Min(p1.thingIDNumber, p2.thingIDNumber);
+            var b = Math.Max(p1.thingIDNumber, p2.thingIDNumber);
+            return (a, b);
+        }
+
+        private static bool RecentlyTriggered(Pawn p1, Pawn p2)
+        {
+            if (Current.Game == null) return false;
+            var key = PairKey(p1, p2);
+            if (_cooldown.TryGetValue(key, out var lastTick))
+            {
+                return Find.TickManager.TicksGame - lastTick < CooldownTicks;
+            }
+            return false;
+        }
+
+        private static void MarkTriggered(Pawn p1, Pawn p2)
+        {
+            if (Current.Game == null) return;
+            _cooldown[PairKey(p1, p2)] = Find.TickManager.TicksGame;
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Helpers
+        // ─────────────────────────────────────────────────────────────────────────
+        private static Pawn GetPrimaryPartner(Pawn pawn)
+        {
+            if (pawn?.relations == null) return null;
+
+            // Prioritize spouse > fiance > lover (alive only)
+            Pawn p = pawn.relations.GetFirstDirectRelationPawn(PawnRelationDefOf.Spouse, x => !x.Dead);
+            if (p == null)
+                p = pawn.relations.GetFirstDirectRelationPawn(PawnRelationDefOf.Fiance, x => !x.Dead);
+            if (p == null)
+                p = pawn.relations.GetFirstDirectRelationPawn(PawnRelationDefOf.Lover, x => !x.Dead);
+
+            return p;
+        }
+
+        private static bool HasTrait(Pawn pawn, TraitDef trait)
+        {
+            try
+            {
+                return pawn?.story?.traits?.HasTrait(trait) ?? false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static bool InSameMapAndSpawned(params Pawn[] pawns)
+        {
+            if (pawns == null || pawns.Length == 0) return false;
+            var map = pawns[0]?.Map;
+            if (map == null) return false;
+            foreach (var p in pawns)
+            {
+                if (p == null || p.Map != map || !p.Spawned) return false;
+            }
+            return true;
+        }
+
+        private static float DistanceFactor(Pawn a, Pawn b)
+        {
+            var d = a.Position.DistanceTo(b.Position);
+            if (d <= NearbyDist8) return 1.50f;
+            if (d <= NearbyDist16) return 1.20f;
+            return 1.00f;
+        }
+
+        private static bool MeetsLOSCondition(Pawn observer, Pawn target)
+        {
+            if (!RequireLineOfSight) return true;
+            var map = observer.Map;
+            if (map == null) return false;
+            try
+            {
+                return GenSight.LineOfSight(observer.Position, target.Position, map, true);
+            }
+            catch
+            {
+                // Be permissive if LOS check fails for any reason
+                return true;
+            }
+        }
+
+        private static void TryGainMemorySafe(Pawn pawn, string thoughtDefName, Pawn other = null)
+        {
+            if (pawn?.needs?.mood?.thoughts?.memories == null) return;
+            var def = DefDatabase<ThoughtDef>.GetNamedSilentFail(thoughtDefName);
+            if (def != null)
+            {
+                pawn.needs.mood.thoughts.memories.TryGainMemory(def, other);
+            }
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Interaction selection weight
+        // ─────────────────────────────────────────────────────────────────────────
         public override float RandomSelectionWeight(Pawn initiator, Pawn recipient)
         {
             if (initiator == null || recipient == null) return 0f;
-            // Check if the initiator has a romantic partner
-            Pawn partner = null;
-            if (initiator.relations != null)
-            {
-                partner = initiator.relations.GetFirstDirectRelationPawn(PawnRelationDefOf.Lover, (p) => !p.Dead);
-            }
-            if (partner == null && initiator.relations != null)
-            {
-                partner = initiator.relations.GetFirstDirectRelationPawn(PawnRelationDefOf.Fiance, (p) => !p.Dead);
-            }
-            if (partner == null && initiator.relations != null)
-            {
-                partner = initiator.relations.GetFirstDirectRelationPawn(PawnRelationDefOf.Spouse, (p) => !p.Dead);
-            }
+            if (!InSameMapAndSpawned(initiator, recipient)) return 0f;
 
-            // If the initiator has a partner, and that partner is the recipient of the interaction...
-            if (partner != null && partner == recipient)
-            {
-                // ...check if the partner is on a date with someone else.
-                Pawn cheatingPartner = DatingManager.GetPartnerOnDateWith(partner);
-                if (cheatingPartner != null && cheatingPartner != initiator)
-                {
-                    // 50% chance to notice
-                    return 0.5f;
-                }
-            }
+            // Initiator must have a romantic partner and that partner must be the recipient
+            var partner = GetPrimaryPartner(initiator);
+            if (partner == null || partner != recipient) return 0f;
 
-            return 0f;
+            // If the partner is currently on a date with someone (and that someone isn't the initiator), we may trigger
+            var cheatingPartner = DatingManager.GetPartnerOnDateWith(partner);
+            if (cheatingPartner == null || cheatingPartner == initiator) return 0f;
+            if (!InSameMapAndSpawned(initiator, recipient, cheatingPartner)) return 0f;
+
+            // Cooldown: don't spam
+            if (RecentlyTriggered(initiator, recipient)) return 0f;
+
+            // Optional visibility gating
+            if (!MeetsLOSCondition(initiator, recipient) && !MeetsLOSCondition(initiator, cheatingPartner))
+                return 0f;
+
+            // Start with base chance and adjust
+            float weight = BaseChance;
+
+            // Proximity matters
+            weight *= DistanceFactor(initiator, recipient);
+            weight *= DistanceFactor(initiator, cheatingPartner);
+
+            // Trait influence (jealous partners more likely to notice)
+            if (HasTrait(initiator, TraitDefOf.Jealous)) weight *= 1.25f;
+
+            // Clamp between 0 and 1 for safety
+            weight = Math.Max(0f, Math.Min(1f, weight));
+            return weight;
         }
 
-        public override void Interacted(Pawn initiator, Pawn recipient, List<RulePackDef> extraSentencePacks, out string letterText, out string letterLabel, out LetterDef letterDef, out LookTargets lookTargets)
+        // ─────────────────────────────────────────────────────────────────────────
+        // When the interaction actually happens
+        // ─────────────────────────────────────────────────────────────────────────
+        public override void Interacted(
+            Pawn initiator,
+            Pawn recipient,
+            List<RulePackDef> extraSentencePacks,
+            out string letterText,
+            out string letterLabel,
+            out LetterDef letterDef,
+            out LookTargets lookTargets)
         {
             letterText = null;
             letterLabel = null;
             letterDef = null;
             lookTargets = null;
 
-            Pawn cheatingPartner = DatingManager.GetPartnerOnDateWith(recipient);
-            if (cheatingPartner != null)
-            {
-                // Apply the "Caught Cheating" thought to the initiator
-                if (initiator.needs != null && initiator.needs.mood != null && initiator.needs.mood.thoughts != null && initiator.needs.mood.thoughts.memories != null)
-                {
-                    initiator.needs.mood.thoughts.memories.TryGainMemory(ThoughtDef.Named("CaughtCheating"), recipient);
-                }
+            if (initiator == null || recipient == null) return;
 
-                // Make the LLM call
-                string subject = string.Format("{0} caught {1} cheating with {2}", initiator.Name.ToStringShort, recipient.Name.ToStringShort, cheatingPartner.Name.ToStringShort);
-                InteractionDef caughtCheatingInteractionDef = DefDatabase<InteractionDef>.GetNamed("CaughtCheating");
-                if (caughtCheatingInteractionDef != null)
-                {
-                    SocialInteractions.HandleNonStoppingInteraction(initiator, recipient, caughtCheatingInteractionDef, subject);
-                }
+            // Confirm the recipient is on a date with someone else (the cheater)
+            Pawn cheatingPartner = DatingManager.GetPartnerOnDateWith(recipient);
+            if (cheatingPartner == null || cheatingPartner == initiator) return;
+
+            // Thoughts: give the discoverer a memory; optionally tag the others if you have defs
+            TryGainMemorySafe(initiator, "CaughtCheating", recipient);      // primary memory for the observer
+            TryGainMemorySafe(recipient, "WasCaughtCheating", initiator);   // optional; define in your mod
+            TryGainMemorySafe(cheatingPartner, "AffairExposed", initiator); // optional; define in your mod
+
+            // Compose a letter for the player
+            letterLabel = "Infidelity Discovered";
+            letterText = $"{initiator.LabelShortCap} caught {recipient.LabelShort} cheating with {cheatingPartner.LabelShort}.";
+
+            // Use a negative letter (can be changed to NeutralEvent if preferred)
+            letterDef = LetterDefOf.NegativeEvent;
+
+            // Provide look targets (filter nulls just in case)
+            var targets = new List<Thing> { initiator, recipient, cheatingPartner }.Where(t => t != null);
+            lookTargets = new LookTargets(targets);
+
+            // Fire a non-blocking social interaction / notification hook (if your mod uses it)
+            var caughtCheatingInteractionDef = DefDatabase<InteractionDef>.GetNamedSilentFail("CaughtCheating");
+            if (caughtCheatingInteractionDef != null)
+            {
+                string subject = $"{initiator.NameShortColored} caught {recipient.NameShortColored} cheating with {cheatingPartner.NameShortColored}";
+                SocialInteractions.HandleNonStoppingInteraction(initiator, recipient, caughtCheatingInteractionDef, subject);
             }
+
+            // Mark cooldown to prevent immediate repeats
+            MarkTriggered(initiator, recipient);
         }
     }
 }


### PR DESCRIPTION
Consolidated partner lookup: added GetPrimaryPartner that prioritizes Spouse → Fiance → Lover and ignores dead pawns. This removes repeated null checks and reflects RimWorld’s relationship importance.

Spam protection (cooldown): added an in‑memory cooldown map keyed by pawn pair for ~1 in‑game day (60k ticks), so the event won’t fire every few seconds when conditions persist.

Contextual weighting:

Distance factor: higher chance when the cheaters are nearer (≤8 and ≤16 cells tiers).

Line‑of‑sight (optional): switchable RequireLineOfSight gate; if enabled, requires LOS to either partner or cheater.

Trait influence: jealous pawns are more likely to notice (TraitDefOf.Jealous).

Robust map checks: guard against pawns being on different maps or not spawned to prevent weird edge cases and errors.

Safe memory application: TryGainMemorySafe wraps memory gain and silently ignores missing ThoughtDefs (e.g., optional WasCaughtCheating, AffairExposed) to avoid hard mod dependencies.

Cleaner letter & targets: now returns a proper NegativeEvent letter with LookTargets for all involved pawns, making it visible and actionable for the player.

Noise‑free selection: added a RecentlyTriggered check inside RandomSelectionWeight so the interaction weight drops to 0 during cooldown, avoiding UI spam and performance churn.

Safer utilities: helper methods like InSameMapAndSpawned, HasTrait, and MeetsLOSCondition reduce null dereferences and keep the core logic readable.

Non-blocking hook preserved: kept SocialInteractions.HandleNonStoppingInteraction but made it safe via GetNamedSilentFail, and improved the subject string with colored short names.

Defensive clamps: final weight is clamped to [0, 1] to satisfy InteractionWorker expectations and avoid flukes from multipliers.